### PR TITLE
Update to 0.12 syntax; add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,34 @@ Requirements
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -	[Go](https://golang.org/doc/install) >=1.9 (to build the provider plugin)
 
+
+Building The Provider
+---------------------
+Make sure you have Go installed and your `$GOPATH` setup.
+
+Clone the repo:
+
+```sh
+$ mkdir -p $GOPATH/src/github.com/john-terrell
+$ cd $GOPATH/src/github.com/john-terrell
+$ git clone https://github.com/john-terrell/terraform-provider-smartos.git
+```
+
+Build the provider
+
+```sh
+$ cd $GOPATH/src/github.com/john-terrell/terraform-provider-smartos
+$ go get
+$ make build
+```
+
+In your Terraform project, initialize it by passing the directory that contains the built provider binary.
+
+```sh
+$ cd ~/git/my_terra_project
+$ terraform init --plugin-dir=$GOPATH/bin
+```
+
 Using the provider
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ resource "smartos_machine" "illumos" {
       "pkgin -y update",
       "pkgin -y in htop",
     ]
+    connection {
+      type     = "ssh"
+      host     = self.primary_ip
+      user     = "root"
+      private_key = file("~/.ssh/id_rsa")
+    }
   }
 }
 
@@ -171,6 +177,12 @@ resource "smartos_machine" "linux-kvm" {
       "apt-get update",
       "apt-get -y install htop",
     ]
+    connection {
+      type     = "ssh"
+      host     = self.primary_ip
+      user     = "root"
+      private_key = file("~/.ssh/id_rsa")
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ SmartOS Terraform Provider
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.9 (to build the provider plugin)
+-	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
+-	[Go](https://golang.org/doc/install) >=1.9 (to build the provider plugin)
 
 Using the provider
 ------------------
@@ -51,135 +51,126 @@ The following example shows you how to configure two simple zones - one running 
 
 ```hcl
 provider "smartos" {
-    "host" = "10.99.50.60:22"
-    "user" = "root"
+  host = "10.99.50.60:22"
+  user = "root"
 }
 
 data "smartos_image" "illumos" {
-    "name" = "base-64-lts"
-    "version"  = "18.4.0"
+  name    = "base-64-lts"
+  version = "18.4.0"
 }
 
 data "smartos_image" "linux" {
-    "name" = "ubuntu-16.04"
-    "version"  = "20170403"
+  name    = "ubuntu-16.04"
+  version = "20170403"
 }
 
 data "smartos_image" "linux_kvm" {
-    "name" = "ubuntu-certified-16.04"
-    "version" = "20190212"
+  name    = "ubuntu-certified-16.04"
+  version = "20190212"
 }
 
 resource "smartos_machine" "illumos" {
-    "alias" = "illumos"
-    "brand" = "joyent"
-    "cpu_cap" = 100
+  alias   = "provider-test-illumos"
+  brand   = "joyent"
+  cpu_cap = 100
 
-    # These fields are required in order for provisioning (below) to function.
-    "customer_metadata" = {
-        "root_authorized_keys" = "... copy this from your ~/.ssh/id_rsa.pub ..."
-        "user-script" = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+    "user-script"          = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
+  }
 
-    "image_uuid" = "${data.smartos_image.illumos.id}"
-    "maintain_resolvers" = true
-    "max_physical_memory" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.222/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net4"
-        }
+  image_uuid          = data.smartos_image.illumos.id
+  maintain_resolvers  = true
+  max_physical_memory = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.222/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net4"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  provisioner "remote-exec" {
+    inline = [
+      "pkgin -y update",
+      "pkgin -y in htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    provisioner "remote-exec" {
-        inline = [
-            "pkgin -y update",
-            "pkgin -y in htop",
-        ]
-    }
+  }
 }
 
 resource "smartos_machine" "linux" {
-    "alias" = "provider-test-linux"
-    "brand" = "lx"
-    "kernel_version" = "3.16.0"
-    "cpu_cap" = 100
+  alias          = "provider-test-linux"
+  brand          = "lx"
+  kernel_version = "3.16.0"
+  cpu_cap        = 100
 
-    "customer_metadata" = {
-        # Note: this is my public SSH key...use your own.  :-)
-        "root_authorized_keys" = "... copy this from your ~/.ssh/id_rsa.pub ..."
-        "user-script" = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+    "user-script"          = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
+  }
 
-    "image_uuid" = "${data.smartos_image.linux.id}"
-    "maintain_resolvers" = true
-    "max_physical_memory" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.223/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net5"
-        }
+  image_uuid          = data.smartos_image.linux.id
+  maintain_resolvers  = true
+  max_physical_memory = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.223/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net5"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "apt-get -y install htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    provisioner "remote-exec" {
-        inline = [
-            "apt-get update",
-            "apt-get -y install htop",
-        ]
-    }
+  }
 }
 
 resource "smartos_machine" "linux-kvm" {
-    "alias" = "provider-test-linux-kvm"
-    "brand" = "kvm"
-    "kernel_version" = "3.16.0"
-    "vcpus" = 2
+  alias          = "provider-test-linux-kvm"
+  brand          = "kvm"
+  kernel_version = "3.16.0"
+  vcpus          = 2
 
-    "customer_metadata" = {
-        # Note: this is my public SSH key...use your own.  :-)
-        "root_authorized_keys" = "... copy this from your ~/.ssh/id_rsa.pub ..."
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+  }
 
-    "maintain_resolvers" = true
-    "ram" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.224/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net0"
-            "model" = "virtio"
-        }
+  maintain_resolvers = true
+  ram                = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.224/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net0"
+    model     = "virtio"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  disks {
+    boot        = true
+    image_uuid  = data.smartos_image.linux_kvm.id
+    compression = "lz4"
+    model       = "virtio"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "apt-get -y install htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    "disks" = [
-        {
-            "boot" = true
-            "image_uuid" = "${data.smartos_image.linux_kvm.id}"
-            "compression" = "lz4"
-            "model" = "virtio"
-        }
-    ]
-
-    provisioner "remote-exec" {
-        inline = [
-            "apt-get update",
-            "apt-get -y install htop",
-        ]
-    }
+  }
 }
-
 ```

--- a/sample.tf
+++ b/sample.tf
@@ -1,131 +1,123 @@
 provider "smartos" {
-    "host" = "10.99.50.60:22"
-    "user" = "root"
+  host = "10.99.50.60:22"
+  user = "root"
 }
 
 data "smartos_image" "illumos" {
-    "name" = "base-64-lts"
-    "version"  = "18.4.0"
+  name    = "base-64-lts"
+  version = "18.4.0"
 }
 
 data "smartos_image" "linux" {
-    "name" = "ubuntu-16.04"
-    "version"  = "20170403"
+  name    = "ubuntu-16.04"
+  version = "20170403"
 }
 
 data "smartos_image" "linux_kvm" {
-    "name" = "ubuntu-certified-16.04"
-    "version" = "20190212"
+  name    = "ubuntu-certified-16.04"
+  version = "20190212"
 }
 
 resource "smartos_machine" "illumos" {
-    "alias" = "provider-test-illumos"
-    "brand" = "joyent"
-    "cpu_cap" = 100
+  alias   = "provider-test-illumos"
+  brand   = "joyent"
+  cpu_cap = 100
 
-    "customer_metadata" = {
-        # Note: this is my public SSH key...use your own.  :-)
-        "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
-        "user-script" = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+    "user-script"          = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
+  }
 
-    "image_uuid" = "${data.smartos_image.illumos.id}"
-    "maintain_resolvers" = true
-    "max_physical_memory" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.222/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net4"
-        }
+  image_uuid          = data.smartos_image.illumos.id
+  maintain_resolvers  = true
+  max_physical_memory = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.222/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net4"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  provisioner "remote-exec" {
+    inline = [
+      "pkgin -y update",
+      "pkgin -y in htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    provisioner "remote-exec" {
-        inline = [
-            "pkgin -y update",
-            "pkgin -y in htop",
-        ]
-    }
+  }
 }
 
 resource "smartos_machine" "linux" {
-    "alias" = "provider-test-linux"
-    "brand" = "lx"
-    "kernel_version" = "3.16.0"
-    "cpu_cap" = 100
+  alias          = "provider-test-linux"
+  brand          = "lx"
+  kernel_version = "3.16.0"
+  cpu_cap        = 100
 
-    "customer_metadata" = {
-        # Note: this is my public SSH key...use your own.  :-)
-        "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
-        "user-script" = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+    "user-script"          = "/usr/sbin/mdata-get root_authorized_keys > ~root/.ssh/authorized_keys"
+  }
 
-    "image_uuid" = "${data.smartos_image.linux.id}"
-    "maintain_resolvers" = true
-    "max_physical_memory" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.223/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net5"
-        }
+  image_uuid          = data.smartos_image.linux.id
+  maintain_resolvers  = true
+  max_physical_memory = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.223/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net5"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "apt-get -y install htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    provisioner "remote-exec" {
-        inline = [
-            "apt-get update",
-            "apt-get -y install htop",
-        ]
-    }
+  }
 }
 
 resource "smartos_machine" "linux-kvm" {
-    "alias" = "provider-test-linux-kvm"
-    "brand" = "kvm"
-    "kernel_version" = "3.16.0"
-    "vcpus" = 2
+  alias          = "provider-test-linux-kvm"
+  brand          = "kvm"
+  kernel_version = "3.16.0"
+  vcpus          = 2
 
-    "customer_metadata" = {
-        # Note: this is my public SSH key...use your own.  :-)
-        "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
-    }
+  customer_metadata = {
+    # Note: this is my public SSH key...use your own.  :-)
+    "root_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYIHv3DoXnAMn+dggUup1a+jjSqpZiIU5ThgljXHG9KM+iy1W3zo9qshUE7vBj/l7l5aHzRKyXsmWb6EdmtlVBnYl7SH5IMGaEFlB6n7T+yoMRl7VczZZxvP+VSAac2HeLPvdrCDeJCckfkHeTg9E3rt2PcAz0REKDCm34lpsedgM4QrVh8D54NgqLCdpT+QpidEBwE1T5wGMId4OwBB+r1VJZyn+lstJreQ0mu67qn3TFKu5AxZoTdDj6BSDqqHEos5KirS4pz3zt3r5IbC3mv8vDm9+o6O5M2f7R6RRNfD9IPJANmO0k2Ajf529I0bGgAGgIpIXb8OaI6G+L48dR john@Johns-MacBook-Pro.local"
+  }
 
-    "maintain_resolvers" = true
-    "ram" = 512
-    "nics" = [
-        {
-            "nic_tag" = "external"
-            "ips" = ["10.0.222.224/16"]
-            "gateways" = ["10.0.0.1"]
-            "interface" = "net0"
-            "model" = "virtio"
-        }
+  maintain_resolvers = true
+  ram                = 512
+  nics {
+    nic_tag   = "external"
+    ips       = ["10.0.222.224/16"]
+    gateways  = ["10.0.0.1"]
+    interface = "net0"
+    model     = "virtio"
+  }
+  quota = 25
+
+  resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  disks {
+    boot        = true
+    image_uuid  = data.smartos_image.linux_kvm.id
+    compression = "lz4"
+    model       = "virtio"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "apt-get -y install htop",
     ]
-    "quota" = 25
-
-    "resolvers" = ["1.1.1.1", "1.0.0.1"]
-
-    "disks" = [
-        {
-            "boot" = true
-            "image_uuid" = "${data.smartos_image.linux_kvm.id}"
-            "compression" = "lz4"
-            "model" = "virtio"
-        }
-    ]
-
-    provisioner "remote-exec" {
-        inline = [
-            "apt-get update",
-            "apt-get -y install htop",
-        ]
-    }
+  }
 }

--- a/sample.tf
+++ b/sample.tf
@@ -47,6 +47,12 @@ resource "smartos_machine" "illumos" {
       "pkgin -y update",
       "pkgin -y in htop",
     ]
+    connection {
+      type     = "ssh"
+      host     = self.primary_ip
+      user     = "root"
+      private_key = file("~/.ssh/id_rsa")
+    }
   }
 }
 
@@ -119,5 +125,11 @@ resource "smartos_machine" "linux-kvm" {
       "apt-get update",
       "apt-get -y install htop",
     ]
+    connection {
+      type     = "ssh"
+      host     = self.primary_ip
+      user     = "root"
+      private_key = file("~/.ssh/id_rsa")
+    }
   }
 }


### PR DESCRIPTION
I'm new to Terraform, so perhaps these fixes are horribly naive. But I was able to get this provider working with 0.12 with only modifications to the configuration syntax itself.

I also added build instructions (lifted almost verbatim from terraform-provider-triton).